### PR TITLE
Create .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# IntelliJ
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# Local todo list
+todo.txt
+
+# Other
+bin/
+*.swp
+


### PR DESCRIPTION
Creating a .gitignore file will help contributors to avoid committing unwanted 
files like IDE-based project setttings or temporary files.
